### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,6 @@
 name: Build and Test React Application
+permissions:
+    contents: read
 on:
     push:
         branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/laura-lucciola/firefly-castle-development-main-page/security/code-scanning/1](https://github.com/laura-lucciola/firefly-castle-development-main-page/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/build-and-test.yml` at the workflow root so it applies to all jobs (including `build_test`).  
For the current steps, the minimal safe permission is:

- `contents: read`

This preserves existing functionality (checkout and reading code) while ensuring `GITHUB_TOKEN` is not granted broader write scopes by default settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
